### PR TITLE
feat: remove legalOfficer attribute from JWT token.

### DIFF
--- a/src/logion/app.ts
+++ b/src/logion/app.ts
@@ -27,6 +27,6 @@ createConnection()
 
         expressOasGenerator.handleRequests();
 
-        const port = process.env.PORT || 8081;
+        const port = process.env.PORT || 8090;
         app.listen(port, () => logger.info(`Server started on port ${ port }`));
     });

--- a/test/unit/controllers/health.controller.spec.ts
+++ b/test/unit/controllers/health.controller.spec.ts
@@ -5,7 +5,7 @@ import { Mock } from "moq.ts";
 import { HealthController } from '../../../src/logion/controllers/health.controller';
 import { AuthenticationService } from '../../../src/logion/services/authentication.service';
 import { LegalOfficerRepository } from "../../../src/logion/model/legalofficer.model";
-import { PolkadotService } from 'src/logion/services/polkadot.service';
+import { AuthorityService } from "../../../src/logion/services/authority.service";
 
 describe('HealthController', () => {
 
@@ -64,9 +64,9 @@ const EXPECTED_TOKEN = "the-health-check-token";
 const UNEXPECTED_TOKEN = "wrong-health-check-token";
 
 function bindMocks(container: Container, up: boolean): void {
-    const polkadotService = new Mock<PolkadotService>();
+    const authorityService = new Mock<AuthorityService>();
 
-    container.bind(AuthenticationService).toConstantValue(new AuthenticationService(polkadotService.object()));
+    container.bind(AuthenticationService).toConstantValue(new AuthenticationService(authorityService.object()));
 
     const legalOfficerRepository = new Mock<LegalOfficerRepository>();
     if(up) {

--- a/test/unit/controllers/legalofficer.controller.spec.ts
+++ b/test/unit/controllers/legalofficer.controller.spec.ts
@@ -110,7 +110,7 @@ function mockDataMergeService(container: Container) {
     const authenticationService = new Mock<AuthenticationService>();
     container.bind(AuthenticationService).toConstantValue(authenticationService.object());
     authenticationService.setup(instance => instance.authenticatedUser(It.IsAny<Request>()))
-        .returns(new LogionUserCheck({address: AUTHENTICATED_ADDRESS, legalOfficer:true}));
+        .returns(new LogionUserCheck({address: AUTHENTICATED_ADDRESS}, (address => Promise.resove(LEGAL_OFFICERS.find(description => description.address === address)))));
 
     const authorityService = new Mock<AuthorityService>();
     container.bind(AuthorityService).toConstantValue(authorityService.object());
@@ -141,7 +141,7 @@ function mockRepository(container: Container, authenticatedAddressIsLegalOfficer
     const authenticationService = new Mock<AuthenticationService>()
     container.bind(AuthenticationService).toConstantValue(authenticationService.object())
     authenticationService.setup(instance => instance.authenticatedUser(It.IsAny<Request>()))
-        .returns(new LogionUserCheck({address: AUTHENTICATED_ADDRESS, legalOfficer:true}))
+        .returns(new LogionUserCheck({address: AUTHENTICATED_ADDRESS}, (address => Promise.resove(LEGAL_OFFICERS.find(description => description.address === address)))))
 
     const authorityService = new Mock<AuthorityService>()
     container.bind(AuthorityService).toConstantValue(authorityService.object())

--- a/test/unit/services/authentication.service.spec.ts
+++ b/test/unit/services/authentication.service.spec.ts
@@ -1,14 +1,13 @@
 import { AuthenticationService } from "../../../src/logion/services/authentication.service";
-import { Mock } from "moq.ts";
+import { Mock, It } from "moq.ts";
 import { Request } from "express";
 import { UnauthorizedException } from "dinoloop/modules/builtin/exceptions/exceptions";
-import { PolkadotService } from "src/logion/services/polkadot.service";
 import moment from "moment";
-import { ApiPromise } from "@polkadot/api";
+import { AuthorityService } from "../../../src/logion/services/authority.service";
 
 const USER_TOKEN = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MzEyMTc2MTEsImxlZ2FsT2ZmaWNlciI6ZmFsc2UsImV4cCI6NDc4NDgxNzYxMSwiaXNzIjoiZXhhbXBsZS5vcmciLCJzdWIiOiI1SDRNdkFzb2JmWjZiQkNEeWo1ZHNyV1lMckE4SHJSemFxYTlwNjFVWHR4TWhTQ1kifQ.03P4Ehzp6cweQPct0tf-dBNmkXhFKYfcUYA1xbmPsdpRV9Dn2as1aZdp6neP2iOI"
 const USER_TOKEN_WRONG_SIGNATURE = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MzEyMTc2MTEsImxlZ2FsT2ZmaWNlciI6ZmFsc2UsImV4cCI6NDc4NDgxNzYxMSwiaXNzIjoiZXhhbXBsZS5vcmciLCJzdWIiOiI1SDRNdkFzb2JmWjZiQkNEeWo1ZHNyV1lMckE4SHJSemFxYTlwNjFVWHR4TWhTQ1kifQ.GTLJB_uMjsdcuWzM3CWL92n1UNI0WYXFUDW7QQ1Vi6k3TQIEvG_WwMuuZ2d9cexY"
-const LEGAL_OFFICER_TOKEN = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MzEyMTc2MTEsImxlZ2FsT2ZmaWNlciI6dHJ1ZSwiZXhwIjo0Nzg0ODE3NjExLCJpc3MiOiJleGFtcGxlLm9yZyIsInN1YiI6IjVINE12QXNvYmZaNmJCQ0R5ajVkc3JXWUxyQThIclJ6YXFhOXA2MVVYdHhNaFNDWSJ9.tZ-VKXDRt-3U7BrTogm1FmVtcC5L1krdYg_c2kAYDUnfjr-IG4s3msylYohjQLPd"
+const LEGAL_OFFICER_TOKEN = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MzEyMTc2MTEsImV4cCI6NDc4NDgxNzYxMSwiaXNzIjoiZXhhbXBsZS5vcmciLCJzdWIiOiI1SDRNdkFzb2JmWjZiQkNEeWo1ZHNyV1lMckE4SHJSemFxYTlwNjFVWHR4TWhTQ1kifQ.7X-8bX3l5MMDMBSjgjrZYEwXs07rL0xp5cvqn1ecQN7x1PH40eE4Cf1sDghKa8ER"
 const USER_ADDRESS = "5H4MvAsobfZ6bBCDyj5dsrWYLrA8HrRzaqa9p61UXtxMhSCY"
 const TTL = 100 * 365 * 24 * 3600; // 100 years
 
@@ -19,108 +18,80 @@ process.env.JWT_TTL_SEC = "3600";
 describe('AuthenticationService createToken()', () => {
 
     it('generates a token for legal officer', async () => {
-        givenPolkadotService(USER_ADDRESS);
-        const authenticationService = new AuthenticationService(polkadotService.object());
+        givenAuthorityService(true);
+        const authenticationService = new AuthenticationService(authorityService.object());
         const actual = await authenticationService.createToken(USER_ADDRESS, moment.unix(1631217611), TTL);
         expect(actual.value).toBe(LEGAL_OFFICER_TOKEN)
         expect(actual.expiredOn.unix).toBe(moment.unix(1631217611 + TTL).unix)
     })
 })
 
-function givenPolkadotService(legalOfficerAddress?: string) {
-    polkadotService = new Mock<PolkadotService>();
-    const api: any = {
-        query: {
-            loAuthorityList: {
-                legalOfficerSet: (address: string) => {
-                    if(address === legalOfficerAddress) {
-                        return Promise.resolve({
-                            isSome: true,
-                            unwrap: () => ({
-                                isTrue: true
-                            })
-                        });
-                    } else {
-                        return Promise.resolve({
-                            isSome: false,
-                            unwrap: () => { throw new Error() }
-                        });
-                    }
-                }
-            }
-        }
-    };
-    polkadotService.setup(instance => instance.readyApi()).returns(Promise.resolve(api as ApiPromise));
+function givenAuthorityService(isLegalOfficer?: boolean) {
+    authorityService = new Mock<AuthorityService>();
+    authorityService.setup(instance => instance.isLegalOfficer(It.IsAny<string>()))
+        .returns(Promise.resolve(isLegalOfficer ? isLegalOfficer : false))
 }
 
-let polkadotService: Mock<PolkadotService>;
+
+let authorityService: Mock<AuthorityService>;
 
 describe('AuthenticationService authenticatedUserIs()', () => {
 
     it('authenticates user based on token', () => {
-        givenPolkadotService();
-        const authenticationService = new AuthenticationService(polkadotService.object());
+        givenAuthorityService();
+        const authenticationService = new AuthenticationService(authorityService.object());
         const request = new Mock<Request>();
         request.setup(instance => instance.header("Authorization")).returns("Bearer " + USER_TOKEN)
         const logionUser = authenticationService.authenticatedUserIs(request.object(), USER_ADDRESS);
-        expect(logionUser.legalOfficer).toBe(false);
+        expect(logionUser.address).toBe(USER_ADDRESS);
     })
 
     it('authenticates legal officer based on token', () => {
-        givenPolkadotService(USER_ADDRESS);
-        const authenticationService = new AuthenticationService(polkadotService.object());
+        givenAuthorityService(true);
+        const authenticationService = new AuthenticationService(authorityService.object());
         const request = new Mock<Request>();
         request.setup(instance => instance.header("Authorization")).returns("Bearer " + LEGAL_OFFICER_TOKEN)
         const logionUser = authenticationService.authenticatedUserIs(request.object(), USER_ADDRESS);
-        expect(logionUser.legalOfficer).toBe(true);
         logionUser.requireLegalOfficer();
     })
 
     it('does not authenticate user different from token', () => {
-        givenPolkadotService();
+        givenAuthorityService();
         testForFailure((authenticationService: AuthenticationService, request: Request) => {
             authenticationService.authenticatedUserIs(request, "SOME-OTHER-USER")
         }, "Bearer " + USER_TOKEN, "User has not access to this resource")
     })
 
     it('does not authenticate null user', () => {
-        givenPolkadotService();
+        givenAuthorityService();
         testForFailure((authenticationService: AuthenticationService, request: Request) => {
             authenticationService.authenticatedUserIs(request, null)
         }, "Bearer " + USER_TOKEN, "User has not access to this resource")
     })
 
     it('does not authenticate undefined user', () => {
-        givenPolkadotService();
+        givenAuthorityService();
         testForFailure((authenticationService: AuthenticationService, request: Request) => {
             authenticationService.authenticatedUserIs(request, undefined)
         }, "Bearer " + USER_TOKEN, "User has not access to this resource")
     })
 
     it('does not authenticate invalid header', () => {
-        givenPolkadotService();
+        givenAuthorityService();
         testForFailure((authenticationService: AuthenticationService, request: Request) => {
             authenticationService.authenticatedUserIs(request, "SOME-OTHER-USER")
         }, "fake-auth-header", "Invalid Authorization header")
     })
 
-    it('does not authenticate regular user as legal officer', () => {
-        givenPolkadotService();
-        testForFailure((authenticationService: AuthenticationService, request: Request) => {
-            authenticationService.authenticatedUserIs(request, USER_ADDRESS)
-                .requireLegalOfficer();
-        }, "Bearer " + USER_TOKEN, "Reserved to legal officer")
-    })
-
     it('does not authenticate fake token', () => {
-        givenPolkadotService();
+        givenAuthorityService();
         testForFailure((authenticationService: AuthenticationService, request: Request) => {
             authenticationService.authenticatedUserIs(request, USER_ADDRESS);
         }, "Bearer FAKE", "JsonWebTokenError: jwt malformed")
     })
 
     it('does not authenticate token with wrong signature', () => {
-        givenPolkadotService();
+        givenAuthorityService();
         testForFailure((authenticationService: AuthenticationService, request: Request) => {
             authenticationService.authenticatedUserIs(request, USER_ADDRESS);
         }, "Bearer " + USER_TOKEN_WRONG_SIGNATURE, "JsonWebTokenError: invalid signature")
@@ -130,27 +101,25 @@ describe('AuthenticationService authenticatedUserIs()', () => {
 describe('AuthenticationService authenticatedUserIsOneOf()', () => {
 
     it('authenticates user based on token', () => {
-        givenPolkadotService();
-        const authenticationService = new AuthenticationService(polkadotService.object());
+        givenAuthorityService();
+        const authenticationService = new AuthenticationService(authorityService.object());
         const request = new Mock<Request>();
         request.setup(instance => instance.header("Authorization")).returns("Bearer " + USER_TOKEN)
-        const logionUser = authenticationService.authenticatedUserIsOneOf(request.object(), "FAKE ADDRESS", USER_ADDRESS);
-        expect(logionUser.legalOfficer).toBe(false);
+        authenticationService.authenticatedUserIsOneOf(request.object(), "FAKE ADDRESS", USER_ADDRESS);
     })
 
     it('authenticates legal officer based on token', () => {
-        givenPolkadotService(USER_ADDRESS);
-        const authenticationService = new AuthenticationService(polkadotService.object());
+        givenAuthorityService(true);
+        const authenticationService = new AuthenticationService(authorityService.object());
         const request = new Mock<Request>();
         request.setup(instance => instance.header("Authorization")).returns("Bearer " + LEGAL_OFFICER_TOKEN)
         const logionUser = authenticationService.authenticatedUserIsOneOf(request.object(), "FAKE ADDRESS", USER_ADDRESS);
-        expect(logionUser.legalOfficer).toBe(true);
         logionUser.requireLegalOfficer();
     })
 })
 
 function testForFailure(fnToCheck: (authenticationService: AuthenticationService, request: Request) => void, authHeader: string, expectedError: string) {
-    const authenticationService = new AuthenticationService(polkadotService.object());
+    const authenticationService = new AuthenticationService(authorityService.object());
     const request = new Mock<Request>();
     request.setup(instance => instance.header("Authorization")).returns(authHeader)
 


### PR DESCRIPTION
logion-network/logion-internal#370

- Remove useless JWT attribute `legalOfficer`.
- Use `AuthorityService`.