### PR TITLE
Exclude LOs without settings from list

### DIFF
--- a/src/logion/services/legalofficerdatamerge.service.ts
+++ b/src/logion/services/legalofficerdatamerge.service.ts
@@ -31,11 +31,13 @@ export class LegalOfficerDataMergeService {
 
         const fullList: LegalOfficerDescription[] = [];
         for(const address of Object.keys(chainLegalOfficersMap)) {
-            fullList.push(this.mergeDbChainData({
-                address,
-                chainData: chainLegalOfficersMap[address],
-                dbData: dbLegalOfficersMap[address],
-            }));
+            if(address in dbLegalOfficersMap) {
+                fullList.push(this.mergeDbChainData({
+                    address,
+                    chainData: chainLegalOfficersMap[address],
+                    dbData: dbLegalOfficersMap[address],
+                }));
+            }
         }
 
         fullList.sort((lo1, lo2) => lo1.userIdentity.lastName.localeCompare(lo2.userIdentity.lastName));

--- a/test/unit/services/legalofficerdatamerge.service.spec.ts
+++ b/test/unit/services/legalofficerdatamerge.service.spec.ts
@@ -111,25 +111,4 @@ function thenResultMatches(set: LegalOfficerDescription[]) {
 }
 
 const PARTIAL_DESCRIPTION_SET: LegalOfficerDescription[] = LEGAL_OFFICERS.slice(1);
-PARTIAL_DESCRIPTION_SET.push({
-    address: LEGAL_OFFICERS[0].address,
-    userIdentity: {
-        firstName: "",
-        lastName: "",
-        email: "",
-        phoneNumber: "",
-    },
-    postalAddress: {
-        company: "",
-        line1: "",
-        line2: "",
-        postalCode: "",
-        city: "",
-        country: "",
-    },
-    additionalDetails: "",
-    node: "",
-    logoUrl: "",
-});
-
 const PARTIAL_DB_SET: LegalOfficerAggregateRoot[] = LEGAL_OFFICERS.slice(1).map(mockAggregate);


### PR DESCRIPTION
This will ensure that only the LOs which already configured their "profile" are actually exposed to the end user when choosing a LO for protection or LOC creation.

logion-network/logion-internal#591